### PR TITLE
surfaceflinger: change usageBits type to uint64_t

### DIFF
--- a/services/surfaceflinger/BufferQueueLayer.cpp
+++ b/services/surfaceflinger/BufferQueueLayer.cpp
@@ -563,7 +563,7 @@ status_t BufferQueueLayer::setDefaultBufferProperties(uint32_t w, uint32_t h, Pi
         return BAD_VALUE;
     }
 
-    uint32_t usageBits = 0;
+    uint64_t usageBits = getEffectiveUsage(0);
 
     if (mName == FOD_LAYER_NAME) {
         usageBits = getFodUsageBits(usageBits, false);
@@ -575,7 +575,7 @@ status_t BufferQueueLayer::setDefaultBufferProperties(uint32_t w, uint32_t h, Pi
 
     setDefaultBufferSize(w, h);
     mConsumer->setDefaultBufferFormat(format);
-    mConsumer->setConsumerUsageBits(getEffectiveUsage(usageBits));
+    mConsumer->setConsumerUsageBits(usageBits);
 
     return NO_ERROR;
 }

--- a/services/surfaceflinger/CompositionEngine/include/compositionengine/FodExtension.h
+++ b/services/surfaceflinger/CompositionEngine/include/compositionengine/FodExtension.h
@@ -23,6 +23,6 @@
 #define FOD_TOUCHED_LAYER_NAME "Fingerprint on display.touched#0"
 
 extern uint32_t getFodZOrder(uint32_t z, bool touched);
-extern uint32_t getFodUsageBits(uint32_t usageBits, bool touched);
+extern uint64_t getFodUsageBits(uint64_t usageBits, bool touched);
 
 #endif /* __FOD_EXTENSION__H__ */

--- a/services/surfaceflinger/CompositionEngine/src/FodExtension.cpp
+++ b/services/surfaceflinger/CompositionEngine/src/FodExtension.cpp
@@ -22,7 +22,7 @@ uint32_t getFodZOrder(uint32_t z, bool touched) {
     return z;
 }
 
-uint32_t getFodUsageBits(uint32_t usageBits, bool touched) {
+uint64_t getFodUsageBits(uint64_t usageBits, bool touched) {
     (void) touched;
     return usageBits;
 }


### PR DESCRIPTION
with uint32_t, it will loose the bits and making the usageBits invalid.

Co-authored-by: Michael Benedict <michaelbt@live.com>
Change-Id: I7b873ddd80e904dfc7fa8c3100ffbdf5f50d83e1